### PR TITLE
Indent fix

### DIFF
--- a/usr.bin/indent/indent.c
+++ b/usr.bin/indent/indent.c
@@ -1050,8 +1050,10 @@ check_type:
 						}
 					}
 				} else {
-					if (dec_ind && s_code != e_code)
-						dump_line();
+					if (dec_ind && s_code != e_code) {
+					    *e_code = '\0';
+					    dump_line();
+					}
 					dec_ind = 0;
 					ps.want_blank = false;
 				}

--- a/usr.bin/indent/indent.c
+++ b/usr.bin/indent/indent.c
@@ -344,6 +344,8 @@ main(int argc, char **argv)
 						 * follows the if, or whatever */
 			switch (type_code) {
 			case newline:
+                if (sc_end != NULL)
+                    goto sw_buffer; /* dump comment, if any */
 				++line_no;
 				flushed_nl = true;
 			case form_feed:

--- a/usr.bin/indent/indent.c
+++ b/usr.bin/indent/indent.c
@@ -763,9 +763,10 @@ check_type:
 			break;
 
 		case semicolon:/* got a ';' */
-			ps.in_or_st = false;	/* we are not in an
-						 * initialization or structure
-						 * declaration */
+            if (ps.dec_nest == 0) {
+                /* we are not in an initialization or structure declaration */
+                ps.in_or_st = false;
+            }
 			scase = false;	/* these will only need resetting in a
 					 * error */
 			squest = 0;


### PR DESCRIPTION
indent(1) simply wasn't taught that "else" may be followed by a comment
without any opening brace anywhere on the line, so it was very confused
in such cases. 
And dump_line() requires s_code to be a string, because it will call count_spaces().